### PR TITLE
API Replace deprecated FormField::createTag() with static create_tag()

### DIFF
--- a/code/fields/KeyValueField.php
+++ b/code/fields/KeyValueField.php
@@ -35,9 +35,9 @@ class KeyValueField extends MultiValueTextField {
 						'tabindex' => $this->getAttribute('tabindex')
 					);
 
-					$keyField = $this->createTag('span', $fieldAttr, Convert::raw2xml($i));
+					$keyField = FormField::create_tag('span', $fieldAttr, Convert::raw2xml($i));
 					$fieldAttr['id'] = $this->id().':'.$v;
-					$valField = $this->createTag('span', $fieldAttr, Convert::raw2xml($v));
+					$valField = FormField::create_tag('span', $fieldAttr, Convert::raw2xml($v));
 					$fields[] = $keyField . $valField;
 				} else {
 					$keyField = $this->createSelectList($i, $nameKey, $this->sourceKeys, $i);
@@ -60,7 +60,7 @@ class KeyValueField extends MultiValueTextField {
 	}
 
 	protected function createSelectList($number, $name, $values, $selected = '') {
-		$options = $this->createTag(
+		$options = FormField::create_tag(
 			'option',
 			array(
 				'selected' => $selected == '' ? 'selected' : '',
@@ -74,7 +74,7 @@ class KeyValueField extends MultiValueTextField {
 			if ($index == $selected) {
 				$attrs['selected'] = 'selected';
 			}
-			$options .= $this->createTag('option', $attrs, Convert::raw2xml($title));
+			$options .= FormField::create_tag('option', $attrs, Convert::raw2xml($title));
 		}
 
 		if (count($values)) {
@@ -87,7 +87,7 @@ class KeyValueField extends MultiValueTextField {
 
 			if($this->disabled) $attrs['disabled'] = 'disabled';
 
-			return $this->createTag('select', $attrs, $options);
+			return FormField::create_tag('select', $attrs, $options);
 		} else {
 			$attrs = array(
 				'class' => 'text mventryfield mvtextfield ' . ($this->extraClass() ? $this->extraClass() : ''),
@@ -100,7 +100,7 @@ class KeyValueField extends MultiValueTextField {
 
 			if($this->disabled) $attrs['disabled'] = 'disabled';
 
-			return $this->createTag('input', $attrs);
+			return FormField::create_tag('input', $attrs);
 		}
 	}
 	

--- a/code/fields/MultiValueDropdownField.php
+++ b/code/fields/MultiValueDropdownField.php
@@ -46,7 +46,7 @@ class MultiValueDropdownField extends MultiValueTextField {
 						'name' => $name,
 						'tabindex' => $this->getAttribute('tabindex')
 					);
-					$fields[] = $this->createTag('span', $fieldAttr, Convert::raw2xml($v));
+					$fields[] = FormField::create_tag('span', $fieldAttr, Convert::raw2xml($v));
 				} else {
 					$fields[] = $this->createSelectList($i, $name, $this->source, $v);
 				}
@@ -67,7 +67,7 @@ class MultiValueDropdownField extends MultiValueTextField {
 	}
 
 	protected function createSelectList($number, $name, $values, $selected = '') {
-		$options = $this->createTag(
+		$options = FormField::create_tag(
 			'option',
 			array(
 				'selected' => $selected == '' ? 'selected' : '',
@@ -81,7 +81,7 @@ class MultiValueDropdownField extends MultiValueTextField {
 			if ($index == $selected) {
 				$attrs['selected'] = 'selected';
 			}
-			$options .= $this->createTag('option', $attrs, Convert::raw2xml($title));
+			$options .= FormField::create_tag('option', $attrs, Convert::raw2xml($title));
 		}
 
 		$attrs = array(
@@ -93,6 +93,6 @@ class MultiValueDropdownField extends MultiValueTextField {
 
 		if($this->disabled) $attrs['disabled'] = 'disabled';
 
-		return $this->createTag('select', $attrs, $options);
+		return FormField::create_tag('select', $attrs, $options);
 	}
 }

--- a/code/fields/MultiValueListField.php
+++ b/code/fields/MultiValueListField.php
@@ -30,7 +30,7 @@ class MultiValueListField extends MultiValueTextField {
 			if (in_array($index, $this->value)) {
 				$attrs['selected'] = 'selected';
 			}
-			$options .= $this->createTag('option', $attrs, Convert::raw2xml($title));
+			$options .= FormField::create_tag('option', $attrs, Convert::raw2xml($title));
 		}
 
 		$attrs = array(
@@ -43,6 +43,6 @@ class MultiValueListField extends MultiValueTextField {
 
 		if($this->disabled) $attrs['disabled'] = 'disabled';
 
-		return $this->createTag('select', $attrs, $options);
+		return FormField::create_tag('select', $attrs, $options);
 	}
 }

--- a/code/fields/MultiValueTextField.php
+++ b/code/fields/MultiValueTextField.php
@@ -71,11 +71,11 @@ class MultiValueTextField extends FormField {
 	}
 
 	public function createReadonlyInput($attributes, $value) {
-		return $this->createTag('span', $attributes, Convert::raw2xml($value));
+		return FormField::create_tag('span', $attributes, Convert::raw2xml($value));
 	}
 
 	public function createInput($attributes) {
-		return $this->createTag('input', $attributes);
+		return FormField::create_tag('input', $attributes);
 	}
 
 	public function  performReadonlyTransformation() {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "silverstripe/multivaluefield",
+	"name": "maldicore/multivaluefield",
 	"description": "A DB field + form fields for storing multiple values in a single property (serialized).",
 	"type": "silverstripe-module",
 	"keywords": ["silverstripe", "formfield", "dbfield"],


### PR DESCRIPTION
GridField uses createTag() which is marked for deprecation, rather than have it used as the cornerstone of generating FormField templates, use it as a helper in case fields generate HTML tags from PHP.