### PR TITLE
Remove master build, branch isn't compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ matrix:
     - php: 5.3
       env: DB=PGSQL CORE_RELEASE=3.1
     - php: 5.4
-      env: DB=MYSQL CORE_RELEASE=master
-    - php: 5.5
-      env: DB=MYSQL CORE_RELEASE=master
+      env: DB=MYSQL CORE_RELEASE=3.2
 
 before_script:
  - phpenv rehash

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,6 @@
 		}
 	],
 	"require": {
-		"silverstripe/framework": ">=3.0.0"
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "2.1.x-dev"
-		}
+		"silverstripe/framework": "~3.0"
 	}
 }


### PR DESCRIPTION
Add a 3.2 test instead. Also removes a branch-alias which is no longer applicable,
since 2.1 is now an actual branch, hence master would need to be at least aliased to 2.2, or 3.0.