### PR TITLE
Implementing "ItemByKey" method

### DIFF
--- a/src/ORM/FieldType/MultiValueField.php
+++ b/src/ORM/FieldType/MultiValueField.php
@@ -167,12 +167,12 @@ class MultiValueField extends DBComposite
         return '';
     }
     
-    public function ItemsByKey()
+    public function ItemByKey()
     {
-        $value = $this->getValue();
-        if(array_keys($value) == range(0, count($value) - 1))
-            $value = [];
-        return new ArrayData($value);
+        $values = $this->getValue();
+        if(array_keys($values) == range(0, count($values) - 1))
+            $values = [];
+        return new ArrayData($values);
     }
 
     public function Items()

--- a/src/ORM/FieldType/MultiValueField.php
+++ b/src/ORM/FieldType/MultiValueField.php
@@ -166,6 +166,14 @@ class MultiValueField extends DBComposite
 
         return '';
     }
+    
+    public function ItemsByKey()
+    {
+        $value = $this->getValue();
+        if(array_keys($value) == range(0, count($value) - 1))
+            $value = [];
+        return new ArrayData($value);
+    }
 
     public function Items()
     {


### PR DESCRIPTION
With this method we can get values keyed.
For example, if we have this KeyValueField

```
new KeyValueField('MyField', 'MyField', array(
   "AAA" => "AAAValue",
   "BBB" => "BBBValue",
   "CCC" => "CCCValue"
))
```
in template and in php code we can get the keyed value in this mode:

// template
`MyField.ItemByKey.AAA`

// php Code
`$this->dbObject('MyField')->ItemByKey()->AAA;`