### PR TITLE
MNT Refactor test to use assertStringContainsString()

### DIFF
--- a/tests/MultiValueFieldTest.php
+++ b/tests/MultiValueFieldTest.php
@@ -18,10 +18,10 @@ class MultiValueFieldTest extends SapphireTest
 
     public function testUpdate()
     {
-        $obj          = new MultiValueFieldTest_DataObject();
+        $obj = new MultiValueFieldTest_DataObject();
         $obj->MVField = ['One', 'Two'];
         $obj->write();
-        $obj          = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
+        $obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
         $obj->MVField = ['Three'];
         $obj->write();
         $this->assertEquals(['Three'], $obj->obj('MVField')->getValues());
@@ -29,20 +29,20 @@ class MultiValueFieldTest extends SapphireTest
 
     public function testSetArrayAsProperty()
     {
-        $obj          = new MultiValueFieldTest_DataObject();
+        $obj = new MultiValueFieldTest_DataObject();
         $obj->MVField = ['One', 'Two'];
         $obj->write();
-        $obj          = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
+        $obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
         $this->assertNotNull($obj->MVField);
         $this->assertEquals(['One', 'Two'], $obj->obj('MVField')->getValues());
     }
 
     public function testSetSerialisedStringAsProperty()
     {
-        $obj          = new MultiValueFieldTest_DataObject();
+        $obj = new MultiValueFieldTest_DataObject();
         $obj->MVField = serialize(['One', 'Two']);
         $obj->write();
-        $obj          = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
+        $obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
         $this->assertNotNull($obj->MVField);
 
         $this->assertEquals(['One', 'Two'], $obj->obj('MVField')->getValues());
@@ -50,10 +50,10 @@ class MultiValueFieldTest extends SapphireTest
 
     public function testSetJsonStringAsProperty()
     {
-        $obj          = new MultiValueFieldTest_DataObject();
+        $obj = new MultiValueFieldTest_DataObject();
         $obj->MVField = json_encode(['One', 'Two']);
         $obj->write();
-        $obj          = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
+        $obj = MultiValueFieldTest_DataObject::get()->byID($obj->ID);
         $this->assertNotNull($obj->MVField);
 
         $this->assertEquals(['One', 'Two'], $obj->obj('MVField')->getValues());
@@ -63,13 +63,9 @@ class MultiValueFieldTest extends SapphireTest
     {
 
         $field = new MultiValueField();
-
         $field->setValue(['one' => 'one']);
-
         $this->assertEquals(['one' => 'one'], $field->getValue());
-
         $field->setValue([]);
-
         $this->assertEquals([], $field->getValue());
     }
 

--- a/tests/MultiValueTextFieldTest.php
+++ b/tests/MultiValueTextFieldTest.php
@@ -17,16 +17,17 @@ class MultiValueTextFieldTest extends SapphireTest
     public function testAttributesGeneration()
     {
         $field = MultiValueTextField::create('TestTextField', 'Test Text Field');
+        $keySep = MultiValueTextField::KEY_SEP;
 
-        $this->assertContains('id="' . $field->ID() . '"', $field->forTemplate());
-        $this->assertContains('id="' . $field->ID() . MultiValueTextField::KEY_SEP . '0"', $field->forTemplate());
-        $this->assertNotContains('id="' . $field->ID() . MultiValueTextField::KEY_SEP . '1"', $field->forTemplate());
+        $this->assertStringContainsString('id="' . $field->ID() . '"', $field->forTemplate());
+        $this->assertStringContainsString('id="' . $field->ID() . $keySep . '0"', $field->forTemplate());
+        $this->assertStringNotContainsString('id="' . $field->ID() . $keySep . '1"', $field->forTemplate());
 
         $field->setValue(['one']);
-        $this->assertContains('id="' . $field->ID() . MultiValueTextField::KEY_SEP . '1"', $field->forTemplate());
-        $this->assertNotContains('id="' . $field->ID() . MultiValueTextField::KEY_SEP . '2"', $field->forTemplate());
+        $this->assertStringContainsString('id="' . $field->ID() . $keySep . '1"', $field->forTemplate());
+        $this->assertStringNotContainsString('id="' . $field->ID() . $keySep . '2"', $field->forTemplate());
 
         $field->setValue(['one', 'two']);
-        $this->assertContains('id="' . $field->ID() . MultiValueTextField::KEY_SEP . '2"', $field->forTemplate());
+        $this->assertStringContainsString('id="' . $field->ID() . $keySep . '2"', $field->forTemplate());
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/514

`assertContains` in phpunit9 does not support string in string.  This was code was recently merged in from and old pull-request that passed when the tests were run using phpunit5