### PR TITLE
MNT Use full class name

### DIFF
--- a/tests/MultiValueFieldTest.php
+++ b/tests/MultiValueFieldTest.php
@@ -13,7 +13,7 @@ use SilverStripe\CMS\Tests\Controllers\CMSBatchActionsTest;
 class MultiValueFieldTest extends SapphireTest
 {
     protected static $extra_dataobjects = [
-        'MultiValueFieldTest_DataObject'
+        MultiValueFieldTest_DataObject::class
     ];
 
     public function testUpdate()

--- a/tests/MultiValueTextFieldTest.php
+++ b/tests/MultiValueTextFieldTest.php
@@ -11,7 +11,7 @@ use Symbiote\MultiValueField\Fields\MultiValueTextField;
 class MultiValueTextFieldTest extends SapphireTest
 {
     protected static $extra_dataobjects = [
-        'MultiValueFieldTest_DataObject'
+        MultiValueFieldTest_DataObject::class
     ];
 
     public function testAttributesGeneration()


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/580

Fix https://github.com/symbiote/silverstripe-multivaluefield/runs/7643848534?check_suite_focus=true
`Error: Class 'MultiValueFieldTest_DataObject' not found `