### PR TITLE
Update field CSS

### DIFF
--- a/client/css/multivaluefield.css
+++ b/client/css/multivaluefield.css
@@ -1,7 +1,6 @@
 ul.multivaluefieldlist {
     margin: 0;
     padding: 0px;
-    display: block;
     display: flex;
     flex-direction: column;
     gap: 8px;

--- a/client/css/multivaluefield.css
+++ b/client/css/multivaluefield.css
@@ -39,7 +39,3 @@ ul.multivaluefieldlist > li::after {
     font-family: silverstripe !important;
     color: #566b8d;
 }
-
-ul.multivaluefieldlist > li > textarea.mventryfield {
-
-}

--- a/client/css/multivaluefield.css
+++ b/client/css/multivaluefield.css
@@ -1,13 +1,52 @@
-ul.multivaluefieldlist { margin: 0px; padding: 0px;}
-.multivaluefieldlist > li { margin-bottom: 4px; min-width: 250px; list-style-type: none; }
+ul.multivaluefieldlist {
+    margin: 0;
+    padding: 0px;
+    display: block;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
 
-.multivaluefieldlist > li::after { content: '↕'; cursor: pointer; }
-.multivaluefieldlist > li:last-child { margin-bottom: 0; }
-.mventryfield { max-width: 200px !important; display: inline; }
-/*.mventryfield:not(.has-chzn) { display: inline !important; }*/
+ul.multivaluefieldlist > li {
+    margin: 0;
+    padding:0px;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    align-content: stretch;
+    justify-content: space-around;
+    flex: 1;
+    flex-direction: row;
+    list-style-type: none;
+    gap: 8px 6px;
+}
 
-textarea.mventryfield { max-width: none !important; vertical-align: top; }
+ul.multivaluefieldlist > li > .mventryfield {
+    display: block;
+    flex: 6;
+}
 
+ul.multivaluefieldlist > li::after {
+    flex: 0;
+    content: '↕';
+    cursor: ns-resize;
+    display: block;
+    text-align: center;
+    font-size: 24px;
+}
 
-.multivaluefieldlist  .chosen-container { max-width: 90% !important; }
-.field .multivaluefieldlist input.text, .field .multivaluefieldlist select { display: inline; }
+.cms-edit-form ul.multivaluefieldlist > li::after {
+    content: "S";
+    font-family: silverstripe !important;
+    color: #566b8d;
+}
+
+ul.multivaluefieldlist > li > textarea.mventryfield {
+
+}
+
+/*
+.multivaluefieldlist  .chosen-container {
+    max-width: 90% !important;
+}
+*/

--- a/client/css/multivaluefield.css
+++ b/client/css/multivaluefield.css
@@ -44,9 +44,3 @@ ul.multivaluefieldlist > li::after {
 ul.multivaluefieldlist > li > textarea.mventryfield {
 
 }
-
-/*
-.multivaluefieldlist  .chosen-container {
-    max-width: 90% !important;
-}
-*/


### PR DESCRIPTION
## Description

This PR is for some visual enhancements and modernisation of the CSS for display the various multivalue fields, and aligns the fields with other fields in the administration area (e.g. taking up full width of container)

The update:

+ Uses flexbox
+ Field aren't as narrow
+ Added grab icon and updated cursor for reordering
+ General CSS cleanup for readability

![image](https://github.com/symbiote/silverstripe-multivaluefield/assets/603960/194641b1-59c3-4654-98b7-423b290006d1)


## Manual testing steps

Apply the CSS, check for regressions. I haven't found any.

There may be some regressions where the field is used on the frontend, but developers should really be blocking/adding their own CSS there.

## Issues

#105 

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [~] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
